### PR TITLE
Fix RPATH handling on Mac OSX and remove SYSTEM_INSTALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,17 +93,13 @@ foreach ( _var PYTHON_MODULE_PATH LIBRARY_PATH INCLUDE_PATH CONFIG_CMAKE_PATH)
   set ( ${_var} ${OTTEMPLATE_${_var}} )
 endforeach ( _var )
 
-if (CMAKE_INSTALL_PREFIX MATCHES "^/usr")
-  set (SYSTEM_INSTALL ON)
-else ()
-  set (SYSTEM_INSTALL OFF)
-endif ()
-
-# Selectively add or remove RPATH from executable
-if (NOT SYSTEM_INSTALL)
-  set (CMAKE_INSTALL_RPATH ${LIBRARY_PATH})
-  set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-endif ()
+# RPATH settings
+set (CMAKE_INSTALL_RPATH ${LIBRARY_PATH} ${CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES})
+set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+if(POLICY CMP0042)
+  # Set MACOSX_RPATH to ON
+  cmake_policy(SET CMP0042 NEW)
+endif()
 
 # Some useful macros to ease CMakeLists.txt file writing
 set ( SOURCEFILES "" CACHE INTERNAL "List of source files to compile" )

--- a/distro/debian/rules
+++ b/distro/debian/rules
@@ -35,6 +35,7 @@ cmake-configure-%:
             -DCMAKE_C_FLAGS_RELWITHDEBINFO:STRING='$(cflags)' \
             -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING='$(cxxflags)' \
             -DCMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO:STRING='$(ldflags)' \
+            -DCMAKE_SKIP_INSTALL_RPATH:BOOL=ON \
             -DCMAKE_INSTALL_PREFIX:PATH=/usr \
             -DINSTALL_DESTDIR:PATH=$(CURDIR)/debian/ottemplate \
             -DLINK_PYTHON_LIBRARY:BOOL=OFF \
@@ -53,9 +54,7 @@ override_dh_auto_install: $(PYALL:python%=cmake-install-%)
 cmake-install-%:
 	dh_auto_install -Bbuild-python$*
 ifeq (,$(findstring nocheck,$(DEB_BUILD_OPTIONS)))
-	# CTestTestfile.cmake sets LD_LIBRARY_PATH to find libraries in debian/tmp.
-	# But it overrides current value, which breaks when run by fakeroot.
-	[ -z "$$LD_LIBRARY_PATH" ] || sed -i -e "s#;LD_LIBRARY_PATH=[^;]*#&:$$LD_LIBRARY_PATH#" build-python$*/python/test/CTestTestfile.cmake
+	LD_LIBRARY_PATH=$${LD_LIBRARY_PATH:+$${LD_LIBRARY_PATH}:}$(CURDIR)/debian/tmp/usr/lib \
 	CTEST_OUTPUT_ON_FAILURE=1 \
 	  $(MAKE) $(test_makeflags) -C build-python$* test ARGS="$(test_makeflags) -R pyinstallcheck"
 	find $(CURDIR)/debian/ottemplate -name "*.pyc" -o -name "__pycache__" | xargs rm -rf
@@ -79,7 +78,9 @@ cmake-test-%:
 	# 'make test' does not build binary tests
 ifeq (,$(findstring nocheck,$(DEB_BUILD_OPTIONS)))
 	$(MAKE) $(test_makeflags) -C build-python$* tests
-	CTEST_OUTPUT_ON_FAILURE=1 $(MAKE) -C build-python$* test ARGS="$(test_makeflags) -R cppcheck"
+	LD_LIBRARY_PATH=$${LD_LIBRARY_PATH:+$${LD_LIBRARY_PATH}:}$(CURDIR)/debian/tmp/usr/lib \
+	CTEST_OUTPUT_ON_FAILURE=1 \
+        $(MAKE) -C build-python$* test ARGS="$(test_makeflags) -R cppcheck"
 endif
 
 get-orig-source:


### PR DESCRIPTION
The patch is similar to openturns/openturns#46
This fixes path handling on OS X